### PR TITLE
Add property `shouldKeepLoader`

### DIFF
--- a/ImageLoader/ImageLoader.swift
+++ b/ImageLoader/ImageLoader.swift
@@ -194,18 +194,17 @@ public class Manager {
     // MARK: loading
 
     func load(URL: URLLiteralConvertible) -> Loader {
-        let URL = URL.URL
-        if let loader = delegate[URL] {
+        if let loader = delegate[URL.URL] {
             loader.resume()
             return loader
         }
 
-        let request = NSMutableURLRequest(URL: URL)
+        let request = NSMutableURLRequest(URL: URL.URL)
         request.setValue("image/*", forHTTPHeaderField: "Accept")
         let task = session.dataTaskWithRequest(request)
 
         let loader = Loader(task: task, delegate: self)
-        delegate[URL] = loader
+        delegate[URL.URL] = loader
         return loader
     }
 
@@ -402,9 +401,7 @@ public func cancel(URL: URLLiteralConvertible) -> Loader? {
     Fetches the image using the shared manager instance's `ImageCache` object for the specified URL.
 */
 public func cache(URL: URLLiteralConvertible) -> UIImage? {
-    let URL = URL.URL
-
-    return Manager.sharedInstance.cache[URL]
+    return Manager.sharedInstance.cache[URL.URL]
 }
 
 public var state: State {

--- a/ImageLoader/ImageLoader.swift
+++ b/ImageLoader/ImageLoader.swift
@@ -154,6 +154,10 @@ public class Manager {
     let cache: ImageCache
     let delegate: SessionDataDelegate = SessionDataDelegate()
     public var inflatesImage = true
+    /**
+        Use to kill or keep a fetching image loader when it's blocks is to empty by imageview or anyone.
+    */
+    public var shouldKeepLoader = false
 
     private let decompressingQueue = dispatch_queue_create(nil, DISPATCH_QUEUE_CONCURRENT)
 

--- a/ImageLoader/ImageLoader.swift
+++ b/ImageLoader/ImageLoader.swift
@@ -223,7 +223,7 @@ public class Manager {
                 loader.remove(block)
             }
 
-            if loader.blocks.count == 0 || block == nil {
+            if !shouldKeepLoader && loader.blocks.count == 0 {
                 loader.cancel()
                 delegate.remove(URL.URL)
             }

--- a/ImageLoader/UIImageView+ImageLoader.swift
+++ b/ImageLoader/UIImageView+ImageLoader.swift
@@ -45,10 +45,8 @@ extension UIImageView {
             image = placeholder
         }
 
-        let URL = URL.URL
-
-        self.URL = URL
-        _load(URL, completionHandler: completionHandler)
+        self.URL = URL.URL
+        _load(URL.URL, completionHandler: completionHandler)
     }
 
     public func cancelLoading() {

--- a/ImageLoaderTests/ImageLoaderTests.swift
+++ b/ImageLoaderTests/ImageLoaderTests.swift
@@ -147,8 +147,7 @@ class ImageLoaderTests: XCTestCase {
 
         let expectation = expectationWithDescription("wait until loader complete")
 
-        var URL: NSURL!
-        URL = NSURL(string: "http://test/404")
+        let URL = NSURL(string: "http://test/404")!
 
         let manager = Manager()
         let loader = manager.load(URL)
@@ -170,8 +169,7 @@ class ImageLoaderTests: XCTestCase {
 
     func testLoaderCancelWithURL() {
 
-        var URL: NSURL!
-        URL = NSURL(string: "http://test/path")
+        let URL = NSURL(string: "http://test/path")!
 
         let manager: Manager = Manager()
 
@@ -181,9 +179,9 @@ class ImageLoaderTests: XCTestCase {
         manager.load(URL)
         manager.cancel(URL, block: nil)
 
-        let loader2: Loader? = manager.delegate[URL]
-        XCTAssertNil(loader2,
-            "Store doesnt remove the loader, \(loader2)")
+        let loader: Loader? = manager.delegate[URL]
+        XCTAssertNil(loader,
+            "Store doesnt remove the loader, \(loader)")
 
     }
 

--- a/ImageLoaderTests/ImageLoaderTests.swift
+++ b/ImageLoaderTests/ImageLoaderTests.swift
@@ -174,10 +174,12 @@ class ImageLoaderTests: XCTestCase {
         URL = NSURL(string: "http://test/path")
 
         let manager: Manager = Manager()
-        manager.cancel(URL, block: nil)
 
         XCTAssert(manager.state == .Ready,
             "manager's state is not ready, now is \(manager.state.toString())")
+
+        manager.load(URL)
+        manager.cancel(URL, block: nil)
 
         let loader2: Loader? = manager.delegate[URL]
         XCTAssertNil(loader2,

--- a/ImageLoaderTests/ImageLoaderTests.swift
+++ b/ImageLoaderTests/ImageLoaderTests.swift
@@ -66,7 +66,7 @@ class ImageLoaderTests: XCTestCase {
                     }
                 }
 
-                response.responseTime = 0.2
+                response.responseTime = 1
 
                 return response
         })
@@ -185,6 +185,27 @@ class ImageLoaderTests: XCTestCase {
 
     }
 
+    func testLoaderShouldKeepLoader() {
+        let URL = NSURL(string: "http://test/path")!
+
+        let keepingManager = Manager()
+        keepingManager.shouldKeepLoader = true
+        let notkeepingManager = Manager()
+        notkeepingManager.shouldKeepLoader = false
+
+        keepingManager.load(URL)
+        notkeepingManager.load(URL)
+
+        keepingManager.cancel(URL)
+        notkeepingManager.cancel(URL)
+
+        let keepingLoader: Loader? = keepingManager.delegate[URL]
+        let notkeepingLoader: Loader? = notkeepingManager.delegate[URL]
+        XCTAssertNotNil(keepingLoader,
+            "property `shouldKeepLoader is true` doesnt work normally, \(keepingLoader)")
+        XCTAssertNil(notkeepingLoader,
+            "property `shouldKeepLoader is false` doesnt work normally, \(notkeepingLoader)")
+    }
 }
 
 class StringTests: XCTestCase {


### PR DESCRIPTION
After image view start loading another image, previous loading task is possible to live with caching.
- [x] Add property
- [x] UnitTest