### PR TITLE
Fixed synchronization issue

### DIFF
--- a/ImageLoader/Core/HashStorage.swift
+++ b/ImageLoader/Core/HashStorage.swift
@@ -13,13 +13,17 @@ class HashStorage<K: Hashable, V: Equatable> {
     public init() {}
     public subscript(key: K) -> V? {
         get {
+            objc_sync_enter(HashStorage.self)
+            defer { objc_sync_exit(HashStorage.self) }
             return items[key]
         }
         set(value) {
+            objc_sync_enter(HashStorage.self)
+            defer { objc_sync_exit(HashStorage.self) }
             items[key] = value
         }
     }
-
+    
     func getKey(_ value: V) -> K? {
         var key: K?
         items.forEach { k, v in
@@ -27,9 +31,8 @@ class HashStorage<K: Hashable, V: Equatable> {
                 key = k
             }
         }
-
+        
         return key
     }
-
-
+    
 }


### PR DESCRIPTION
Fixed a a synchronization issue which was causing a malloc error, this was due to an edge case where if you scroll too quickly it was reading and writing at the same time.

Credit also goes to @emersonmalca for helping debug.

Anyways I'm sure it can be more robust if we can add some cancellation to it, because at a certain point storage gets overloaded and you don't see anymore images.